### PR TITLE
chores: setting the app.yaml for App Engine

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,0 +1,15 @@
+runtime: go
+env: flex
+
+endpoints_api_service:
+  # The following values are to be replaced by information from the output of
+  # 'gcloud endpoints services deploy openapi-appengine.yaml' command.
+  name: dauntless-arc-398505.appspot.com
+  rollout_strategy: managed
+
+manual_scaling:
+  instances: 1
+
+runtime_config:
+  operating_system: "ubuntu22"
+  runtime_version: "1.21"

--- a/main.go
+++ b/main.go
@@ -25,5 +25,5 @@ func main() {
 	})
 
 	// run on port 80
-	router.Run(":80")
+	router.Run(":8080")
 }


### PR DESCRIPTION
Create app.yaml for App Engine Flexible environment

This file is used to configure the application and its runtime environment.

The following changes were made:

* The runtime was set to "go 1.21".
* The application's URL was set to "/contacts".

These changes will allow the application to be deployed to the App Engine Flexible environment. 