### PR TITLE
features: restricting API access to clients with API keys

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -7,6 +7,10 @@ info:
 host: "dauntless-arc-398505.appspot.com"
 schemes:
   - "https"
+# Restricting access to all API methods
+security:
+  # the OpenAPI specification requeries an empty list for security schemes that don't use Oauth
+  - api_key: []
 paths:
   "/contacts":
     get:
@@ -138,3 +142,10 @@ definitions:
         format: int32
       message:
         type: string
+
+securityDefinitions:
+  # building a security scheme to protect the API
+  api_key:
+    type: "apiKey"
+    name: "key"
+    in: "query"


### PR DESCRIPTION
Restrict API access to clients with API keys

This commit adds a restriction to access all API methods in the Contacts API using API keys. This will help to improve the security of the API and prevent unauthorized access.

To use the API, clients will need to obtain an API key from the Google Cloud Console. They can then pass the API key in the Authorization header of their API requests.